### PR TITLE
商品一覧表示の実装

### DIFF
--- a/app/assets/stylesheets/common/_item.scss
+++ b/app/assets/stylesheets/common/_item.scss
@@ -51,6 +51,10 @@
   }
 }
 
+.show-link {
+  color: #333333;
+}
+
 .three {
   margin-left: 100px;
 }

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -3,7 +3,10 @@ class ProductsController < ApplicationController
 
   def index
     @products = Product.includes(:images).limit(4).order("created_at DESC")
-    # @products = Product.select(category_id: 1).includes(:images).limit(4).order("created_at DESC")
+    @category_men   = Product.includes(:images).where(category_id: 340..470).limit(4).order("created_at DESC")
+    @category_women = Product.includes(:images).where(category_id: 160..339).limit(4).order("created_at DESC")
+    @category_baby  = Product.includes(:images).where(category_id: 471..586).limit(4).order("created_at DESC")
+    @category_cosme = Product.includes(:images).where(category_id: 867..954).limit(4).order("created_at DESC")
   end
 
   def show

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -2,11 +2,11 @@ class ProductsController < ApplicationController
   before_action :set_product, only: [:edit, :update]
 
   def index
-    @products = Product.includes(:images).limit(4).order("created_at DESC")
-    @category_men   = Product.includes(:images).where(category_id: 340..470).limit(4).order("created_at DESC")
-    @category_women = Product.includes(:images).where(category_id: 160..339).limit(4).order("created_at DESC")
-    @category_baby  = Product.includes(:images).where(category_id: 471..586).limit(4).order("created_at DESC")
-    @category_cosme = Product.includes(:images).where(category_id: 867..954).limit(4).order("created_at DESC")
+    @products = Product.include.limited(4)
+    @category_men   = Product.include.category(340..470).limited(4)
+    @category_women = Product.include.category(160..339).limited(4)
+    @category_baby  = Product.include.category(471..586).limited(4)
+    @category_cosme = Product.include.category(867..954).limited(4)
   end
 
   def show

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -24,4 +24,8 @@ class Product < ApplicationRecord
   validates :prefecture_id, presence: { message: "選択してください" }
   validates :shipping_speed_id, presence: { message: "選択してください" }
   validates :user_id, presence: true
+
+  scope :include,  -> { includes(:images) }
+  scope :limited,  -> (count) { order("created_at DESC").limit(count) }
+  scope :category, -> (count) { where(category_id: count) }
 end

--- a/app/views/common/_item.html.haml
+++ b/app/views/common/_item.html.haml
@@ -1,14 +1,15 @@
-.pickup-item__box__item
-  .pickup-item__box__item__image
-    %figure
-      = image_tag "#{product.images.first.url}"
-  .pickup-item__box__item__body
-    %h3.pickup-item__box__item__body__text
-      = product.name
-    .pickup-item__box__item__body__price
-      %p 
-        = product.price
-      .pickup-item__box__item__body__price__icon
-        %p.pickup-item__box__item__body__price__icon__like
-          %i.fa.fa-heart-o
-        %p.pickup-item__box__item__body__price__icon__count 15
+= link_to product_path(product[:id]), class: "show-link" do
+  .pickup-item__box__item
+    .pickup-item__box__item__image
+      %figure
+        = image_tag "#{product.images.first.url}"
+    .pickup-item__box__item__body
+      %h3.pickup-item__box__item__body__text
+        = product.name
+      .pickup-item__box__item__body__price
+        %p 
+          = product.price
+        .pickup-item__box__item__body__price__icon
+          %p.pickup-item__box__item__body__price__icon__like
+            %i.fa.fa-heart-o
+          %p.pickup-item__box__item__body__price__icon__count 15

--- a/app/views/common/_item.html.haml
+++ b/app/views/common/_item.html.haml
@@ -1,4 +1,4 @@
-= link_to product_path(product[:id]), class: "show-link" do
+= link_to product_path(product), class: "show-link" do
   .pickup-item__box__item
     .pickup-item__box__item__image
       %figure

--- a/app/views/common/_item_box.html.haml
+++ b/app/views/common/_item_box.html.haml
@@ -1,6 +1,0 @@
-%p.category__text 新着アイテム
-.pickup-item__box
-  - @products.each do |product|
-    = render partial: "common/item", locals: { product: product }
-.show-items
-  = link_to "すべての商品を見る"

--- a/app/views/common/_item_box_brand.html.haml
+++ b/app/views/common/_item_box_brand.html.haml
@@ -1,0 +1,27 @@
+%p.category__text シャネル 新着アイテム
+.pickup-item__box
+  - @products.each do |product|
+    = render partial: "common/item", locals: { product: product }
+.show-items
+  = link_to "すべての商品を見る"
+
+%p.category__text ルイヴィトン 新着アイテム
+.pickup-item__box
+  - @products.each do |product|
+    = render partial: "common/item", locals: { product: product }
+.show-items
+  = link_to "すべての商品を見る"
+
+%p.category__text シュプリーム 新着アイテム
+.pickup-item__box
+  - @products.each do |product|
+    = render partial: "common/item", locals: { product: product }
+.show-items
+  = link_to "すべての商品を見る"
+
+%p.category__text ナイキ 新着アイテム
+.pickup-item__box
+  - @products.each do |product|
+    = render partial: "common/item", locals: { product: product }
+.show-items
+  = link_to "すべての商品を見る"

--- a/app/views/common/_item_box_category.html.haml
+++ b/app/views/common/_item_box_category.html.haml
@@ -1,0 +1,27 @@
+%p.category__text メンズ 新着アイテム
+.pickup-item__box
+  - @category_men.each do |product|
+    = render partial: "common/item", locals: { product: product }
+.show-items
+  = link_to "すべての商品を見る"
+
+%p.category__text レディース 新着アイテム
+.pickup-item__box
+  - @category_women.each do |product|
+    = render partial: "common/item", locals: { product: product }
+.show-items
+  = link_to "すべての商品を見る"
+
+%p.category__text ベビー・キッズ 新着アイテム
+.pickup-item__box
+  - @category_baby.each do |product|
+    = render partial: "common/item", locals: { product: product }
+.show-items
+  = link_to "すべての商品を見る"
+
+%p.category__text コスメ・香水・美容 新着アイテム
+.pickup-item__box
+  - @category_cosme.each do |product|
+    = render partial: "common/item", locals: { product: product }
+.show-items
+  = link_to "すべての商品を見る"

--- a/app/views/products/index.html.haml
+++ b/app/views/products/index.html.haml
@@ -4,13 +4,11 @@
     .top-banner
       = image_tag "top_page_header_banner.jpg", class: "topbanner"
     .pickup-item
-      - 4.times do
-        %h3.pickup-item__heading ピックアップカテゴリー
-        = render partial: 'common/item_box'
+      %h3.pickup-item__heading ピックアップカテゴリー
+      = render partial: 'common/item_box_category'
     .pickup-item
-      - 4.times do
-        %h3.pickup-item__heading ピックアップブランド
-        = render partial: 'common/item_box'
+      %h3.pickup-item__heading ピックアップブランド
+      = render partial: 'common/item_box_brand'
     .top-banner
       = image_tag "top_page_footer_banner.jpg", class: "topbanner"
   = render partial: 'common/top-footer'


### PR DESCRIPTION
# What
トップページに新着商品の一覧がカテゴリ別で表示されるようにする。（ブランド別の表示は後日実装する。）

# Why
トップページにおける必須の機能のため。

https://gyazo.com/e41dc5203a83daa0404b77c864d5d66c