### PR TITLE
配送先の都道府県_修正

### DIFF
--- a/app/views/products/buy.html.haml
+++ b/app/views/products/buy.html.haml
@@ -28,11 +28,18 @@
         %section.buy_content
           .buy_user_data
             %h3 配送先
-            %address
-              %p 〒#{@product.user.adress.postal_code}
-              %p #{@product.prefecture.name} #{@product.user.adress.city} #{@product.user.adress.block} #{@product.user.adress.building}
-              %p #{@product.user.family_name} #{@product.user.first_name}
-            %p.change_btn 変更する >
+            - if current_user.adress.present?
+              %address
+                %p 〒#{current_user.adress.postal_code}
+                %p #{current_user.adress.prefecture.name} #{current_user.adress.city} #{current_user.adress.block} #{current_user.adress.building}
+                %p #{current_user.family_name} #{current_user.first_name}
+              %p.change_btn 変更する >
+            - else
+              %address
+                %p 〒123-4567
+                %p 東京都 渋谷区 神南 1-1
+                %p テスト ユーザー
+              %p.change_btn 変更する >
         %section.clearfix
           .card
             .card__info

--- a/app/views/products/done.html.haml
+++ b/app/views/products/done.html.haml
@@ -21,10 +21,16 @@
         %section.buy_content
           .buy_user_data
             %h3 配送先
-            %address
-              %p 〒#{@product.user.adress.postal_code}
-              %p #{@product.prefecture.name} #{@product.user.adress.city} #{@product.user.adress.block} #{@product.user.adress.building}
-              %p #{@product.user.family_name} #{@product.user.first_name}
+            - if current_user.adress.present?
+              %address
+                %p 〒#{current_user.adress.postal_code}
+                %p #{current_user.adress.prefecture.name} #{current_user.adress.city} #{current_user.adress.block} #{current_user.adress.building}
+                %p #{current_user.family_name} #{current_user.first_name}
+            - else
+              %address
+                %p 〒123-4567
+                %p 東京都 渋谷区 神南 1-1
+                %p テスト ユーザー
         %section.clearfix
           .card
             .card__info


### PR DESCRIPTION
# What
購入確認ページ、購入完了ページの配送先を修正する。

# Why
配送先未設定の場合のエラーに対応するため。